### PR TITLE
Forward non-sparse data to h5py

### DIFF
--- a/h5sparse/h5sparse.py
+++ b/h5sparse/h5sparse.py
@@ -36,6 +36,9 @@ class Group(object):
     def __init__(self, h5py_group):
         self.h5py_group = h5py_group
 
+    def __contains__(self, item):
+        return self.h5py_group.__contains__(item)
+
     def __getitem__(self, key):
         h5py_item = self.h5py_group[key]
         if isinstance(h5py_item, h5py.Group):

--- a/h5sparse/h5sparse.py
+++ b/h5sparse/h5sparse.py
@@ -66,7 +66,7 @@ class Group(object):
                                  dtype=indices_dtype, **kwargs)
             group.create_dataset('indptr', data=data.h5py_group['indptr'],
                                  dtype=indptr_dtype, **kwargs)
-        else:
+        elif ss.issparse(data):
             group = self.h5py_group.create_group(name)
             group.attrs['h5sparse_format'] = get_format_str(data)
             group.attrs['h5sparse_shape'] = data.shape
@@ -75,6 +75,10 @@ class Group(object):
                                  dtype=indices_dtype, **kwargs)
             group.create_dataset('indptr', data=data.indptr,
                                  dtype=indptr_dtype, **kwargs)
+        else:
+            # If `data` is not a sparse array, forward the arguments to h5py
+            return self.h5py_group.create_dataset(name, data=data, shape=shape,
+                                                  dtype=dtype, **kwargs)
         return Dataset(group)
 
 

--- a/h5sparse/h5sparse.py
+++ b/h5sparse/h5sparse.py
@@ -37,7 +37,7 @@ class Group(object):
         self.h5py_group = h5py_group
 
     def __contains__(self, item):
-        return self.h5py_group.__contains__(item)
+        return item in self.h5py_group
 
     def __getitem__(self, key):
         h5py_item = self.h5py_group[key]

--- a/h5sparse/tests.py
+++ b/h5sparse/tests.py
@@ -1,4 +1,5 @@
 import os
+import json
 from tempfile import mkstemp
 
 import numpy as np
@@ -17,6 +18,8 @@ def test_create_and_read_dataset():
     with h5sparse.File(h5_path) as h5f:
         h5f.create_dataset('sparse/matrix', data=sparse_matrix)
     with h5sparse.File(h5_path) as h5f:
+        assert 'sparse' in h5f
+        assert 'matrix' in h5f['sparse']
         assert (h5f['sparse']['matrix'][1:3] != sparse_matrix[1:3]).size == 0
         assert (h5f['sparse']['matrix'][2:] != sparse_matrix[2:]).size == 0
         assert (h5f['sparse']['matrix'][:2] != sparse_matrix[:2]).size == 0
@@ -40,6 +43,8 @@ def test_create_dataset_from_dataset():
 
         with h5sparse.File(to_h5_path) as to_h5f:
             to_h5f.create_dataset('sparse/matrix', data=from_dset)
+            assert 'sparse' in to_h5f
+            assert 'matrix' in to_h5f['sparse']
             assert (to_h5f['sparse/matrix'].value != sparse_matrix).size == 0
 
     os.remove(from_h5_path)
@@ -64,4 +69,25 @@ def test_dataset_append():
         h5f['matrix'].append(to_append)
         assert (h5f['matrix'].value != appended_matrix).size == 0
 
+    os.remove(h5_path)
+
+
+def test_numpy_array():
+    h5_path = mkstemp(suffix=".h5")[1]
+    matrix = np.random.rand(3, 5)
+    with h5sparse.File(h5_path) as h5f:
+        h5f.create_dataset('matrix', data=matrix)
+        assert 'matrix' in h5f
+        np.testing.assert_equal(h5f['matrix'].value, matrix)
+    os.remove(h5_path)
+
+
+def test_bytestring():
+    h5_path = mkstemp(suffix=".h5")[1]
+    strings = [str(i) for i in range(100)]
+    data = json.dumps(strings).encode('utf8')
+    with h5sparse.File(h5_path) as h5f:
+        h5f.create_dataset('strings', data=data)
+        assert 'strings' in h5f
+        assert strings == json.loads(h5f['strings'].value.decode('utf8'))
     os.remove(h5_path)


### PR DESCRIPTION
- In `Group.create_dataset()`, test if `data` is a scipy sparse matrix. If not, forward the arguments to h5py and return `h5py.Dataset`.
- Add `__contains__` to `Group`.